### PR TITLE
Simulcast

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "WebRTC", url: "https://github.com/livekit/WebRTC-swift.git", .exact("2.91.0")),
+        .package(name: "WebRTC", url: "https://github.com/webrtc-sdk/Specs.git", .exact("92.4515.03")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.15.0")),
         .package(name: "Promises", url: "https://github.com/google/promises.git", .upToNextMajor(from: "1.2.12")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "WebRTC", url: "https://github.com/webrtc-sdk/Specs.git", .exact("92.4515.03")),
+        .package(name: "WebRTC", url: "https://github.com/webrtc-sdk/Specs.git", .exact("92.4515.06")),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.15.0")),
         .package(name: "Promises", url: "https://github.com/google/promises.git", .upToNextMajor(from: "1.2.12")),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),

--- a/Sources/LiveKit/Types.swift
+++ b/Sources/LiveKit/Types.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Hiroshi Horie on 2021/09/27.
+//
+
+public struct Dimensions {
+    public static let aspectRatio169 = 16.0 / 9.0
+    public static let aspectRatio43 = 4.0 / 3.0
+
+    public let width: Int
+    public let height: Int
+}

--- a/Sources/LiveKit/classes/LocalParticipant.swift
+++ b/Sources/LiveKit/classes/LocalParticipant.swift
@@ -92,8 +92,11 @@ public class LocalParticipant: Participant {
                         let transInit = RTCRtpTransceiverInit()
                         transInit.direction = .sendOnly
                         transInit.streamIds = [self.streamId]
-                        let encodings = track.getVideoEncodings(publishOptions.encoding, simulcast: publishOptions.simulcast)
-                        transInit.sendEncodings = encodings
+
+                        if let encodings = Utils.computeEncodings(dimensions: track.dimensions, publishOptions: publishOptions) {
+                            print("using encodings %@", encodings)
+                            transInit.sendEncodings = encodings
+                        }
 
                         track.transceiver = self.engine?.publisher?.peerConnection.addTransceiver(with: track.mediaTrack, init: transInit)
                         if track.transceiver == nil {

--- a/Sources/LiveKit/classes/SignalClient.swift
+++ b/Sources/LiveKit/classes/SignalClient.swift
@@ -129,7 +129,7 @@ class SignalClient : NSObject {
         sendRequest(req: req)
     }
 
-    func sendAddTrack(cid: String, name: String, type: Livekit_TrackType, dimensions: Track.Dimensions? = nil) {
+    func sendAddTrack(cid: String, name: String, type: Livekit_TrackType, dimensions: Dimensions? = nil) {
         var addTrackReq = Livekit_AddTrackRequest.with {
             $0.cid = cid
             $0.name = name

--- a/Sources/LiveKit/classes/Track.swift
+++ b/Sources/LiveKit/classes/Track.swift
@@ -44,11 +44,6 @@ public class Track {
         }
     }
 
-    public struct Dimensions {
-        public var width: Int
-        public var height: Int
-    }
-
     public internal(set) var name: String
     public internal(set) var sid: String?
     public internal(set) var kind: Track.Kind

--- a/Sources/LiveKit/classes/TrackPublication.swift
+++ b/Sources/LiveKit/classes/TrackPublication.swift
@@ -15,7 +15,7 @@ public class TrackPublication {
     public internal(set) var muted: Bool
 
     /// video-only
-    public internal(set) var dimensions: Track.Dimensions?
+    public internal(set) var dimensions: Dimensions?
 
     /// video-only
     public internal(set) var simulcasted: Bool = false
@@ -40,7 +40,7 @@ public class TrackPublication {
         muted = info.muted
         simulcasted = info.simulcast
         if info.type == .video {
-            dimensions = Track.Dimensions(width: Int(info.width), height: Int(info.height))
+            dimensions = Dimensions(width: Int(info.width), height: Int(info.height))
         }
     }
 }


### PR DESCRIPTION
- [x]  Use new WebRTC build
- [x]  Implement Simulcast

### Know issue
When Simulcast is on, frequently crashes at `publisher.setRemoteDescription`.
Doesn't crash with Flutter SDK (which uses the same WebRTC build), so probably something related with PeerConnection state.
I will look into this when implementing protocol v3.