### PR TITLE
add dtx support

### DIFF
--- a/Sources/LiveKit/core/Engine.swift
+++ b/Sources/LiveKit/core/Engine.swift
@@ -193,11 +193,11 @@ class Engine: MulticastDelegate<EngineDelegate> {
     func addTrack(cid: String,
                   name: String,
                   kind: Livekit_TrackType,
-                  dimensions: Dimensions? = nil) -> Promise<Livekit_TrackInfo> {
+                  _ populator: (inout Livekit_AddTrackRequest) -> ()) -> Promise<Livekit_TrackInfo> {
 
         // TODO: Check if cid already published
 
-        signalClient.sendAddTrack(cid: cid, name: name, type: kind, dimensions: dimensions)
+        signalClient.sendAddTrack(cid: cid, name: name, type: kind, populator)
 
         return waitForPublishTrack(cid: cid)
     }

--- a/Sources/LiveKit/core/SignalClient.swift
+++ b/Sources/LiveKit/core/SignalClient.swift
@@ -255,18 +255,14 @@ extension SignalClient {
     }
 
     func sendAddTrack(cid: String, name: String, type: Livekit_TrackType,
-                      dimensions: Dimensions? = nil) {
+                      _ populator: (inout Livekit_AddTrackRequest) -> ()) {
         logger.debug("[SignalClient] Sending add track request")
-
         let r = Livekit_SignalRequest.with {
             $0.addTrack = Livekit_AddTrackRequest.with {
+                populator(&$0)
                 $0.cid = cid
                 $0.name = name
                 $0.type = type
-                if let dimensions = dimensions {
-                    $0.width = UInt32(dimensions.width)
-                    $0.height = UInt32(dimensions.height)
-                }
             }
         }
 

--- a/Sources/LiveKit/participant/LocalParticipant.swift
+++ b/Sources/LiveKit/participant/LocalParticipant.swift
@@ -35,30 +35,32 @@ public class LocalParticipant: Participant {
         }
 
         let cid = track.mediaTrack.trackId
-        return engine.addTrack(cid: cid, name: track.name, kind: .audio).then { trackInfo in
-
+        return engine.addTrack(cid: cid, name: track.name, kind: .audio) {
+            $0.disableDtx = !(publishOptions?.dtx ?? true)
+        }.then { trackInfo in
+            
             Promise<LocalTrackPublication> { () -> LocalTrackPublication in
-
+                
                 track.start()
-
+                
                 let transInit = RTCRtpTransceiverInit()
                 transInit.direction = .sendOnly
                 transInit.streamIds = [self.streamId]
-
+                
                 let transceiver = self.engine?.publisher?.pc.addTransceiver(with: track.mediaTrack, init: transInit)
                 if transceiver == nil {
                     throw TrackError.publishError("Nil sender returned from peer connection.")
                 }
-
+                
                 engine.publisherShouldNegotiate()
-
+                
                 let publication = LocalTrackPublication(info: trackInfo, track: track, participant: self)
                 self.addTrack(publication: publication)
-
+                
                 // notify didPublish
                 self.notify { $0.localParticipant(self, didPublish: publication) }
                 self.room?.notify { $0.room(self.room!, localParticipant: self, didPublish: publication) }
-
+                
                 return publication
             }
         }
@@ -83,40 +85,42 @@ public class LocalParticipant: Participant {
         let cid = track.mediaTrack.trackId
         return engine.addTrack(cid: cid,
                                name: track.name,
-                               kind: .video,
-                               dimensions: track.dimensions) .then { trackInfo in
-
-                                Promise<LocalTrackPublication> { () -> LocalTrackPublication in
-
-                                    track.start()
-
-                                    let transInit = RTCRtpTransceiverInit()
-                                    transInit.direction = .sendOnly
-                                    transInit.streamIds = [self.streamId]
-
-                                    if let encodings = Utils.computeEncodings(dimensions: track.dimensions,
-                                                                              publishOptions: publishOptions) {
-                                        print("using encodings %@", encodings)
-                                        transInit.sendEncodings = encodings
-                                    }
-
-                                    track.transceiver = self.engine?.publisher?.pc.addTransceiver(with: track.mediaTrack, init: transInit)
-                                    if track.transceiver == nil {
-                                        throw TrackError.publishError("Nil sender returned from peer connection.")
-                                    }
-
-                                    engine.publisherShouldNegotiate()
-
-                                    let publication = LocalTrackPublication(info: trackInfo, track: track, participant: self)
-                                    self.addTrack(publication: publication)
-
-                                    // notify didPublish
-                                    self.notify { $0.localParticipant(self, didPublish: publication) }
-                                    self.room?.notify { $0.room(self.room!, localParticipant: self, didPublish: publication) }
-
-                                    return publication
-                                }
-                               }
+                               kind: .video) {
+            $0.width = UInt32(track.dimensions.width)
+            $0.height = UInt32(track.dimensions.height)
+        }.then { trackInfo in
+            
+            Promise<LocalTrackPublication> { () -> LocalTrackPublication in
+                
+                track.start()
+                
+                let transInit = RTCRtpTransceiverInit()
+                transInit.direction = .sendOnly
+                transInit.streamIds = [self.streamId]
+                
+                if let encodings = Utils.computeEncodings(dimensions: track.dimensions,
+                                                          publishOptions: publishOptions) {
+                    print("using encodings %@", encodings)
+                    transInit.sendEncodings = encodings
+                }
+                
+                track.transceiver = self.engine?.publisher?.pc.addTransceiver(with: track.mediaTrack, init: transInit)
+                if track.transceiver == nil {
+                    throw TrackError.publishError("Nil sender returned from peer connection.")
+                }
+                
+                engine.publisherShouldNegotiate()
+                
+                let publication = LocalTrackPublication(info: trackInfo, track: track, participant: self)
+                self.addTrack(publication: publication)
+                
+                // notify didPublish
+                self.notify { $0.localParticipant(self, didPublish: publication) }
+                self.room?.notify { $0.room(self.room!, localParticipant: self, didPublish: publication) }
+                
+                return publication
+            }
+        }
     }
 
     public func unpublishAll(shouldNotify: Bool = true) -> Promise<[Void]> {

--- a/Sources/LiveKit/types/options/TrackPublishOptions.swift
+++ b/Sources/LiveKit/types/options/TrackPublishOptions.swift
@@ -14,8 +14,11 @@ public struct LocalVideoTrackPublishOptions {
 public struct LocalAudioTrackPublishOptions {
     public var name: String?
     public var bitrate: Int?
+    public var dtx: Bool
 
-    public init() {}
+    public init(dtx: Bool = true) {
+        self.dtx = dtx
+    }
 }
 
 public struct LocalDataTrackPublishOptions {


### PR DESCRIPTION
Wasn't able to find a way to monitor traffic differences from ios simulator, may need a real device for that (Instruments doesn't support network monitoring for simulators).