### PR TITLE
Dynamically update sender parameters

### DIFF
--- a/Sources/LiveKit/core/Engine.swift
+++ b/Sources/LiveKit/core/Engine.swift
@@ -287,7 +287,7 @@ extension Engine {
             transport.add(delegate: delegate!)
         }
         // convert to timed-promise
-        .timeout(5)
+        .timeout(10)
     }
 
     func waitForPublishTrack(cid: String) -> Promise<Livekit_TrackInfo> {
@@ -306,7 +306,7 @@ extension Engine {
             self.signalClient.add(delegate: delegate!)
         }
         // convert to timed-promise
-        .timeout(5)
+        .timeout(10)
     }
 }
 

--- a/Sources/LiveKit/extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -39,7 +39,8 @@ extension RTCVideoCapturerDelegate {
 
     /// capture a `CMSampleBuffer`
     public func capturer(_ capturer: RTCVideoCapturer,
-                         didCapture sampleBuffer: CMSampleBuffer) {
+                         didCapture sampleBuffer: CMSampleBuffer,
+                         withPixelBuffer: ((CVPixelBuffer) -> Void)? = nil) {
 
         // check if buffer is ready
         guard CMSampleBufferGetNumSamples(sampleBuffer) == 1,
@@ -64,6 +65,8 @@ extension RTCVideoCapturerDelegate {
             logger.warning("Failed to capture, pixel buffer not found")
             return
         }
+        
+        withPixelBuffer?(pixelBuffer)
 
         let timeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         let timeStampNs = UInt64(CMTimeGetSeconds(timeStamp) * Double(NSEC_PER_SEC))
@@ -72,5 +75,13 @@ extension RTCVideoCapturerDelegate {
                       didCapture: pixelBuffer,
                       timeStampNs: timeStampNs,
                       rotation: rotation ?? ._0)
+    }
+}
+
+extension CVPixelBuffer {
+
+    func toDimensions() -> Dimensions {
+        Dimensions(width: Int32(CVPixelBufferGetWidth(self)),
+                   height: Int32(CVPixelBufferGetHeight(self)))
     }
 }

--- a/Sources/LiveKit/extensions/RTCVideoCapturerDelegate+Buffer.swift
+++ b/Sources/LiveKit/extensions/RTCVideoCapturerDelegate+Buffer.swift
@@ -65,7 +65,7 @@ extension RTCVideoCapturerDelegate {
             logger.warning("Failed to capture, pixel buffer not found")
             return
         }
-        
+
         withPixelBuffer?(pixelBuffer)
 
         let timeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)

--- a/Sources/LiveKit/participant/LocalParticipant.swift
+++ b/Sources/LiveKit/participant/LocalParticipant.swift
@@ -114,6 +114,9 @@ public class LocalParticipant: Participant {
                     transInit.sendEncodings = encodings
                 }
 
+                // store publishOptions used for this track
+                track.publishOptions = publishOptions
+
                 track.transceiver = self.room?.engine.publisher?.pc.addTransceiver(with: track.mediaTrack, init: transInit)
                 if track.transceiver == nil {
                     throw TrackError.publishError("Failed to addTransceiver")

--- a/Sources/LiveKit/participant/LocalParticipant.swift
+++ b/Sources/LiveKit/participant/LocalParticipant.swift
@@ -255,10 +255,10 @@ extension LocalParticipant {
             // publication already exists
             if enabled {
                 publication.muted = false
-                track.start().then { publication }
+                return track.start().then { publication }
             } else {
                 publication.muted = true
-                track.stop().then { () }
+                return track.stop().then { nil }
             }
         } else if enabled {
             // try to create a new track

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -129,7 +129,7 @@ class Utils {
             }
 
             if max(dimensions.width, dimensions.height) < 960 {
-                // deactivate Q if dimensions are too small
+                // deactivate F if dimensions are too small
                 activateF = false
             }
         }
@@ -137,8 +137,8 @@ class Utils {
         // if simulcast is enabled, always add "h" and "f" encoding parameters
         // but keep it active = false if dimension is too small
         return publishOptions.simulcast ? [
-            RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4),
-            RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2),
+            RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: activateF ? 4 : 2),
+            RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: activateF ? 2 : 1),
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF, scaleDown: 1, active: activateF)
         ] : [
             RTCRtpEncodingParameters(rid: "q", encoding: encodingF)

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -101,12 +101,12 @@ class Utils {
 
         let publishOptions = publishOptions ?? LocalVideoTrackPublishOptions()
 
-        var encodingF: VideoEncoding? = nil
-        var encodingH: VideoEncoding? = nil
-        var encodingQ: VideoEncoding? = nil
+        var encodingF: VideoEncoding?
+        var encodingH: VideoEncoding?
+        var encodingQ: VideoEncoding?
 
         var activateQ = true
-        
+
         // only if dimensions are available, compute encodings
         if let dimensions = dimensions {
             // find presets array 16:9 or 4:3, always small to large order
@@ -116,7 +116,7 @@ class Utils {
             encodingF = presets[presetIndexF].encoding
             encodingH = encodingF
             encodingQ = encodingF
-            
+
             // try to get a 1 step lower encoding preset
             if let e = presets[safe: presetIndexF - 1]?.encoding {
                 encodingH = e
@@ -127,7 +127,7 @@ class Utils {
             if let e = presets[safe: presetIndexF - 2]?.encoding {
                 encodingQ = e
             }
-            
+
             if max(dimensions.width, dimensions.height) < 960 {
                 // deactivate Q if dimensions are too small
                 activateQ = false
@@ -141,7 +141,7 @@ class Utils {
             RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2),
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
         ] : [
-            RTCRtpEncodingParameters(rid: "q", encoding: encodingF),
+            RTCRtpEncodingParameters(rid: "q", encoding: encodingF)
         ]
     }
 }

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -104,8 +104,7 @@ class Utils {
         var encodingF: VideoEncoding? = nil
         var encodingH: VideoEncoding? = nil
         var encodingQ: VideoEncoding? = nil
-        
-        var activateH = true
+
         var activateQ = true
         
         // only if dimensions are available, compute encodings
@@ -139,7 +138,7 @@ class Utils {
         // but keep it active = false if dimension is too small
         return publishOptions.simulcast ? [
             RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4, active: activateQ),
-            RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2, active: activateH),
+            RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2),
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
         ] : [
             RTCRtpEncodingParameters(rid: "q", encoding: encodingF),

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -149,17 +149,6 @@ class Utils {
         result += [
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
         ]
-//
-//        result.append(encoding.toRTCRtpEncoding(rid: "f"))
-//
-//        if dimensions.width >= 960 {
-//            result.append(contentsOf: [
-//                midPreset.encoding.toRTCRtpEncoding(rid: "h", scaleDownBy: 2),
-//                lowPreset.encoding.toRTCRtpEncoding(rid: "q", scaleDownBy: 4)
-//            ])
-//        } else {
-//            result.append(lowPreset.encoding.toRTCRtpEncoding(rid: "h", scaleDownBy: 2))
-//        }
 
         return result
     }

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -135,22 +135,15 @@ class Utils {
             }
         }
 
-        var result: [RTCRtpEncodingParameters] = []
-        
-        if publishOptions.simulcast {
-            // if simulcast is enabled, always add "h" and "q" encoding parameters
-            // but keep it active = false if dimension is too small
-            result += [
-                RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4, active: activateQ),
-                RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2, active: activateH),
-            ]
-        }
-
-        result += [
+        // if simulcast is enabled, always add "h" and "f" encoding parameters
+        // but keep it active = false if dimension is too small
+        return publishOptions.simulcast ? [
+            RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4, active: activateQ),
+            RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2, active: activateH),
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
+        ] else [
+            RTCRtpEncodingParameters(rid: "q", encoding: encodingF),
         ]
-
-        return result
     }
 }
 

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -105,7 +105,7 @@ class Utils {
         var encodingH: VideoEncoding?
         var encodingQ: VideoEncoding?
 
-        var activateQ = true
+        var activateF = true
 
         // only if dimensions are available, compute encodings
         if let dimensions = dimensions {
@@ -130,16 +130,16 @@ class Utils {
 
             if max(dimensions.width, dimensions.height) < 960 {
                 // deactivate Q if dimensions are too small
-                activateQ = false
+                activateF = false
             }
         }
 
         // if simulcast is enabled, always add "h" and "f" encoding parameters
         // but keep it active = false if dimension is too small
         return publishOptions.simulcast ? [
-            RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4, active: activateQ),
+            RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4),
             RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2),
-            RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
+            RTCRtpEncodingParameters(rid: "f", encoding: encodingF, scaleDown: 1, active: activateF)
         ] : [
             RTCRtpEncodingParameters(rid: "q", encoding: encodingF)
         ]

--- a/Sources/LiveKit/support/Utils.swift
+++ b/Sources/LiveKit/support/Utils.swift
@@ -141,7 +141,7 @@ class Utils {
             RTCRtpEncodingParameters(rid: "q", encoding: encodingQ, scaleDown: 4, active: activateQ),
             RTCRtpEncodingParameters(rid: "h", encoding: encodingH, scaleDown: 2, active: activateH),
             RTCRtpEncodingParameters(rid: "f", encoding: encodingF)
-        ] else [
+        ] : [
             RTCRtpEncodingParameters(rid: "q", encoding: encodingF),
         ]
     }

--- a/Sources/LiveKit/track/LocalVideoTrack.swift
+++ b/Sources/LiveKit/track/LocalVideoTrack.swift
@@ -62,21 +62,31 @@ extension LocalVideoTrack: VideoCapturerDelegate {
     }
 
     internal func recomputeSenderParameters() {
-        print("Should re-compute sender parameters")
+        logger.debug("Should re-compute sender parameters")
         guard let sender = transceiver?.sender else {return}
 
         // get current parameters
         let parameters = sender.parameters
-        print("re-compute: \(sender.parameters.encodings)")
 
-        // TODO: Update parameters
+        // re-compute encodings
+        let encodings = Utils.computeEncodings(dimensions: capturer.dimensions,
+                                               publishOptions: publishOptions)
 
-        parameters.degradationPreference = NSNumber(value: RTCDegradationPreference.disabled.rawValue)
+        for current in parameters.encodings {
+            if let new = encodings?.first(where: { $0.rid == current.rid }) {
+                // update parameters for matching rid
+                current.isActive = new.isActive
+                current.maxBitrateBps = new.maxBitrateBps
+                current.maxFramerate = new.maxFramerate
+            }
+        }
+
+        // TODO: Investigate if WebRTC iOS SDK actually uses this value
+        // parameters.degradationPreference = NSNumber(value: RTCDegradationPreference.disabled.rawValue)
 
         // set the updated parameters
         sender.parameters = parameters
 
-        print("re-compute: \(sender.parameters.encodings)")
-
+        logger.debug("Sender parameters updated: \(sender.parameters.encodings)")
     }
 }

--- a/Sources/LiveKit/track/LocalVideoTrack.swift
+++ b/Sources/LiveKit/track/LocalVideoTrack.swift
@@ -90,3 +90,12 @@ extension LocalVideoTrack: VideoCapturerDelegate {
         logger.debug("Sender parameters updated: \(sender.parameters.encodings)")
     }
 }
+
+extension RTCRtpEncodingParameters {
+    open override var description: String {
+        return "RTCRtpEncodingParameters(rid: \(rid ?? "-"), "
+            + "active: \(isActive),"
+            + "maxBitrateBps: \(maxBitrateBps ?? 0), "
+            + "maxFramerate: \(maxFramerate ?? 0))"
+    }
+}

--- a/Sources/LiveKit/track/LocalVideoTrack.swift
+++ b/Sources/LiveKit/track/LocalVideoTrack.swift
@@ -76,6 +76,7 @@ extension LocalVideoTrack: VideoCapturerDelegate {
             if let new = encodings?.first(where: { $0.rid == current.rid }) {
                 // update parameters for matching rid
                 current.isActive = new.isActive
+                current.scaleResolutionDownBy = new.scaleResolutionDownBy
                 current.maxBitrateBps = new.maxBitrateBps
                 current.maxFramerate = new.maxFramerate
             }

--- a/Sources/LiveKit/track/Track.swift
+++ b/Sources/LiveKit/track/Track.swift
@@ -34,6 +34,8 @@ public class Track: MulticastDelegate<TrackDelegate> {
     public var sender: RTCRtpSender? {
         return transceiver?.sender
     }
+    /// ``publishOptions`` used for this track if already published.
+    public internal (set) var publishOptions: LocalVideoTrackPublishOptions?
 
     public private(set) var state: State = .stopped {
         didSet {

--- a/Sources/LiveKit/track/capturers/BufferCapturer.swift
+++ b/Sources/LiveKit/track/capturers/BufferCapturer.swift
@@ -8,7 +8,10 @@ class BufferCapturer: VideoCapturer {
 
     // shortcut
     func capture(_ sampleBuffer: CMSampleBuffer) {
-        delegate?.capturer(capturer, didCapture: sampleBuffer)
+        delegate?.capturer(capturer, didCapture: sampleBuffer) { pixelBuffer in
+            // report dimensions update
+            self.dimensions = pixelBuffer.toDimensions()
+        }
     }
 }
 

--- a/Sources/LiveKit/track/capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/track/capturers/CameraCapturer.swift
@@ -44,6 +44,8 @@ public class CameraCapturer: VideoCapturer {
 
     public func setCameraPosition(_ position: AVCaptureDevice.Position) -> Promise<Void> {
 
+        logger.debug("setCameraPosition(position: \(position)")
+
         // update options to use new position
         options.position = position
 
@@ -52,12 +54,16 @@ public class CameraCapturer: VideoCapturer {
     }
 
     public override func startCapture() -> Promise<Void> {
+
+        logger.debug("CameraCapturer.startCapture()")
+
         let devices = RTCCameraVideoCapturer.captureDevices()
         // TODO: FaceTime Camera for macOS uses .unspecified, fall back to first device
         let device = devices.first { $0.position == options.position } ?? devices.first
 
         guard let device = device else {
-            return Promise(TrackError.mediaError("No camera video capture devices available."))
+            logger.error("No camera video capture devices available")
+            return Promise(TrackError.mediaError("No camera video capture devices available"))
         }
 
         let formats = RTCCameraVideoCapturer.supportedFormats(for: device)
@@ -82,6 +88,7 @@ public class CameraCapturer: VideoCapturer {
         }
 
         guard let selectedDimension = selectedDimension else {
+            logger.error("Could not get dimensions")
             return Promise(TrackError.mediaError("Could not get dimensions"))
         }
 
@@ -161,5 +168,16 @@ extension LocalVideoTrack {
             name: Track.cameraName,
             source: .camera
         )
+    }
+}
+
+extension AVCaptureDevice.Position: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .front: return ".front"
+        case .back: return ".back"
+        case .unspecified: return ".unspecified"
+        default: return "unknown"
+        }
     }
 }

--- a/Sources/LiveKit/track/capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/track/capturers/CameraCapturer.swift
@@ -112,6 +112,7 @@ public class CameraCapturer: VideoCapturer {
 
                     // update internal vars
                     self.device = device
+                    // this will trigger to re-compute encodings for sender parameters if dimensions have updated
                     self.dimensions = selectedDimension
 
                     // successfully started

--- a/Sources/LiveKit/track/capturers/InAppCapturer.swift
+++ b/Sources/LiveKit/track/capturers/InAppCapturer.swift
@@ -14,7 +14,10 @@ class InAppScreenCapturer: VideoCapturer {
                 // TODO: force pixel format kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
                 RPScreenRecorder.shared().startCapture { sampleBuffer, type, _ in
                     if type == .video {
-                        self.delegate?.capturer(self.capturer, didCapture: sampleBuffer)
+                        self.delegate?.capturer(self.capturer, didCapture: sampleBuffer) { pixelBuffer in
+                            // report dimensions update
+                            self.dimensions = pixelBuffer.toDimensions()
+                        }
                     }
                 } completionHandler: { error in
                     if let error = error {

--- a/Sources/LiveKit/track/capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/track/capturers/VideoCapturer.swift
@@ -59,7 +59,9 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     }
 
     public func restartCapture() -> Promise<Void> {
-        stopCapture().recover { _ in
+        stopCapture().recover { error in
+            logger.warning("Capturer was already stopped")
+        }.then {
             self.startCapture()
         }
     }

--- a/Sources/LiveKit/track/capturers/VideoCapturer.swift
+++ b/Sources/LiveKit/track/capturers/VideoCapturer.swift
@@ -41,6 +41,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // will fail if already started (to prevent duplicate code execution)
     public func startCapture() -> Promise<Void> {
         guard state != .started else {
+            logger.warning("Capturer already started")
             return Promise(TrackError.invalidTrackState("Already started"))
         }
 
@@ -51,6 +52,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     // will fail if already stopped (to prevent duplicate code execution)
     public func stopCapture() -> Promise<Void> {
         guard state != .stopped else {
+            logger.warning("Capturer already stopped")
             return Promise(TrackError.invalidTrackState("Already stopped"))
         }
 
@@ -59,7 +61,7 @@ public class VideoCapturer: MulticastDelegate<VideoCapturerDelegate>, VideoCaptu
     }
 
     public func restartCapture() -> Promise<Void> {
-        stopCapture().recover { error in
+        stopCapture().recover { _ in
             logger.warning("Capturer was already stopped")
         }.then {
             self.startCapture()

--- a/Sources/LiveKit/types/Dimensions.swift
+++ b/Sources/LiveKit/types/Dimensions.swift
@@ -51,5 +51,5 @@ extension Dimensions {
 }
 
 extension VideoEncoding {
-    
+
 }

--- a/Sources/LiveKit/types/Dimensions.swift
+++ b/Sources/LiveKit/types/Dimensions.swift
@@ -37,4 +37,19 @@ extension Dimensions {
         }
         return result
     }
+
+    func computeSuggestedPresetIndex(in presets: [VideoParameters]) -> Int {
+        assert(!presets.isEmpty)
+        var result = 0
+        for preset in presets {
+            if width >= preset.dimensions.width, height >= preset.dimensions.height {
+                result += 1
+            }
+        }
+        return result
+    }
+}
+
+extension VideoEncoding {
+    
 }

--- a/Sources/LiveKit/types/VideoEncoding.swift
+++ b/Sources/LiveKit/types/VideoEncoding.swift
@@ -12,7 +12,7 @@ public struct VideoEncoding {
 }
 
 extension RTCRtpEncodingParameters {
-    
+
     convenience init(rid: String? = nil,
                      encoding: VideoEncoding? = nil,
                      scaleDown: Double = 1.0,

--- a/Sources/LiveKit/types/VideoEncoding.swift
+++ b/Sources/LiveKit/types/VideoEncoding.swift
@@ -11,6 +11,24 @@ public struct VideoEncoding {
     }
 }
 
+extension RTCRtpEncodingParameters {
+    
+    convenience init(rid: String? = nil,
+                     encoding: VideoEncoding? = nil,
+                     scaleDown: Double = 1.0,
+                     active: Bool = true) {
+        self.init()
+        self.isActive = active
+        self.rid = rid
+        self.scaleResolutionDownBy = NSNumber(value: scaleDown)
+
+        if let encoding = encoding {
+            self.maxFramerate = NSNumber(value: encoding.maxFps)
+            self.maxBitrateBps = NSNumber(value: encoding.maxBitrate)
+        }
+    }
+}
+
 extension VideoEncoding {
 
     func toRTCRtpEncoding(

--- a/Sources/LiveKit/types/VideoParameters.swift
+++ b/Sources/LiveKit/types/VideoParameters.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebRTC
 
 extension Collection where Element == VideoParameters {
-    
+
     func suggestedPresetIndex(dimensions: Dimensions? = nil,
                               videoEncoding: VideoEncoding? = nil) -> Int {
         // self must at lease have 1 element
@@ -15,13 +15,13 @@ extension Collection where Element == VideoParameters {
             if let dimensions = dimensions,
                dimensions.width >= preset.dimensions.width,
                dimensions.height >= preset.dimensions.height {
-                
+
                 result += 1
             } else if let videoEncoding = videoEncoding,
                       videoEncoding.maxBitrate >= preset.encoding.maxBitrate {
                 result += 1
             }
-           
+
         }
         return result
     }

--- a/Sources/LiveKit/types/VideoParameters.swift
+++ b/Sources/LiveKit/types/VideoParameters.swift
@@ -1,6 +1,32 @@
 import Foundation
 import WebRTC
 
+extension Collection where Element == VideoParameters {
+    
+    func suggestedPresetIndex(dimensions: Dimensions? = nil,
+                              videoEncoding: VideoEncoding? = nil) -> Int {
+        // self must at lease have 1 element
+        assert(!isEmpty)
+        // dimensions or videoEndocing is required
+        assert(dimensions != nil || videoEncoding != nil)
+
+        var result = 0
+        for preset in self {
+            if let dimensions = dimensions,
+               dimensions.width >= preset.dimensions.width,
+               dimensions.height >= preset.dimensions.height {
+                
+                result += 1
+            } else if let videoEncoding = videoEncoding,
+                      videoEncoding.maxBitrate >= preset.encoding.maxBitrate {
+                result += 1
+            }
+           
+        }
+        return result
+    }
+}
+
 public struct VideoParameters {
 
     // 4:3 aspect ratio


### PR DESCRIPTION
The intension for this change is to fix that:
Previously, if there are no dimensions info, simulcast would never be enabled.

With this change simulcast will always be enabled (if its true in the options),
and the sender parameters will **lazily** be updated when dimensions info 
is provided by the capturer. (even when dimensions change)

Many of the capturers cannot report "real dimensions" until they produce a frame,
it's only possible to estimate (which is in accurate)

### Thoughts
What should be the desired behavior when the user provides VideoEncoding(max frameRate, maxBitrate) in the publish options, and Simulcast is enabled.