### PR TITLE
Fix Xcode 12 compile issues

### DIFF
--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -129,15 +129,15 @@ public class Room: MulticastDelegate<RoomDelegate> {
     private func onSignalSpeakersUpdate(_ speakers: [Livekit_SpeakerInfo]) {
         var lastSpeakers = activeSpeakers.reduce(into: [Sid: Participant]()) { $0[$1.sid] = $1 }
         for speaker in speakers {
-            let p = speaker.sid == localParticipant?.sid ? localParticipant : remoteParticipants[speaker.sid]
-            guard let p = p else {
+            
+            guard let participant = speaker.sid == localParticipant?.sid ? localParticipant : remoteParticipants[speaker.sid] else {
                 continue
             }
 
-            p.audioLevel = speaker.level
-            p.isSpeaking = speaker.active
+            participant.audioLevel = speaker.level
+            participant.isSpeaking = speaker.active
             if speaker.active {
-                lastSpeakers[speaker.sid] = p
+                lastSpeakers[speaker.sid] = participant
             } else {
                 lastSpeakers.removeValue(forKey: speaker.sid)
             }

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -32,10 +32,9 @@ internal class Transport: MulticastDelegate<TransportDelegate> {
          delegate: TransportDelegate) throws {
 
         // try create peerConnection
-        let pc = Engine.factory.peerConnection(with: config,
-                                               constraints: RTCMediaConstraints.defaultPCConstraints,
-                                               delegate: nil)
-        guard let pc = pc else {
+        guard let pc = Engine.factory.peerConnection(with: config,
+                                                     constraints: RTCMediaConstraints.defaultPCConstraints,
+                                                     delegate: nil) else {
             throw EngineError.webRTC("failed to create peerConnection")
         }
 

--- a/Sources/LiveKit/Support/Utils.swift
+++ b/Sources/LiveKit/Support/Utils.swift
@@ -24,9 +24,7 @@ class Utils {
         // use default options if nil
         let options = options ?? ConnectOptions()
 
-        let parsedUrl = URL(string: url)
-
-        guard let parsedUrl = parsedUrl else {
+        guard let parsedUrl = URL(string: url) else {
             throw InternalError.parse("Failed to parse url")
         }
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -59,9 +59,8 @@ public class CameraCapturer: VideoCapturer {
 
         let devices = RTCCameraVideoCapturer.captureDevices()
         // TODO: FaceTime Camera for macOS uses .unspecified, fall back to first device
-        let device = devices.first { $0.position == options.position } ?? devices.first
 
-        guard let device = device else {
+        guard let device = devices.first(where: { $0.position == options.position }) ?? devices.first else {
             logger.error("No camera video capture devices available")
             return Promise(TrackError.mediaError("No camera video capture devices available"))
         }


### PR DESCRIPTION
Fixes issue https://github.com/livekit/client-sdk-ios/issues/6#issuecomment-979694895

I have no idea why in some cases Xcode 12 throws compile errors when **unwrapping variable with the same name**

According to SO, this should be valid even for `guard` since Xcode 7.1.1 • Swift 2.1 :
https://stackoverflow.com/a/28709006/1993405

I'm not sure this might be a Swift bug https://bugs.swift.org/browse/SR-214

For now, I will avoid variable shadowing...