### PR TITLE
Pass capture options for `setCameraEnabled` and `setMicrophone`

### DIFF
--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -244,26 +244,17 @@ extension LocalParticipant {
         return set(source: .microphone, enabled: enabled)
     }
 
-    public func setScreenShare(enabled: Bool, source: ScreenShareSource? = nil) -> Promise<LocalTrackPublication?> {
-        return set(source: .screenShareVideo, enabled: enabled, screenShareSource: source)
+    public func setScreenShare(enabled: Bool) -> Promise<LocalTrackPublication?> {
+        return set(source: .screenShareVideo, enabled: enabled)
     }
 
-    public func set(source: Track.Source,
-                    enabled: Bool,
-                    screenShareSource: ScreenShareSource? = nil) -> Promise<LocalTrackPublication?> {
-
+    public func set(source: Track.Source, enabled: Bool) -> Promise<LocalTrackPublication?> {
         let publication = getTrackPublication(source: source)
         if let publication = publication as? LocalTrackPublication,
            let track = publication.track {
             // publication already exists
             if enabled {
                 publication.muted = false
-                #if os(macOS)
-                if let videoTrack = track as? LocalVideoTrack,
-                   let capturer = videoTrack.capturer as? MacOSScreenCapturer {
-                    capturer.source = screenShareSource ?? .mainDisplay
-                }
-                #endif
                 return track.start().then { publication }
             } else {
                 publication.muted = true
@@ -285,10 +276,8 @@ extension LocalParticipant {
                 // iOS defaults to in-app screen share only since background screen share
                 // requires a broadcast extension (iOS limitation).
                 localTrack = LocalVideoTrack.createInAppScreenShareTrack()
-                #endif
-
-                #if os(macOS)
-                localTrack = LocalVideoTrack.createMacOSScreenShareTrack(source: screenShareSource ?? .mainDisplay)
+                #elseif os(macOS)
+                localTrack = LocalVideoTrack.createMacOSScreenShareTrack()
                 #endif
 
                 if let localTrack = localTrack {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -236,17 +236,12 @@ public class LocalParticipant: Participant {
 
 extension LocalParticipant {
 
-    public func setCamera(enabled: Bool,
-                          options: LocalVideoTrackOptions? = nil,
-                          interceptor: VideoCaptureInterceptor? = nil) -> Promise<LocalTrackPublication?> {
-
-        return set(source: .camera, enabled: enabled, videoTrackOptions: options, interceptor: interceptor)
+    public func setCamera(enabled: Bool) -> Promise<LocalTrackPublication?> {
+        return set(source: .camera, enabled: enabled)
     }
 
-    public func setMicrophone(enabled: Bool,
-                              options: LocalAudioTrackOptions? = nil) -> Promise<LocalTrackPublication?> {
-
-        return set(source: .microphone, enabled: enabled, audioTrackOptions: options)
+    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?> {
+        return set(source: .microphone, enabled: enabled)
     }
 
     public func setScreenShare(enabled: Bool, source: ScreenShareSource? = nil) -> Promise<LocalTrackPublication?> {
@@ -255,10 +250,7 @@ extension LocalParticipant {
 
     public func set(source: Track.Source,
                     enabled: Bool,
-                    videoTrackOptions: LocalVideoTrackOptions? = nil,
-                    audioTrackOptions: LocalAudioTrackOptions? = nil,
-                    screenShareSource: ScreenShareSource? = nil,
-                    interceptor: VideoCaptureInterceptor? = nil) -> Promise<LocalTrackPublication?> {
+                    screenShareSource: ScreenShareSource? = nil) -> Promise<LocalTrackPublication?> {
 
         let publication = getTrackPublication(source: source)
         if let publication = publication as? LocalTrackPublication,
@@ -280,11 +272,10 @@ extension LocalParticipant {
         } else if enabled {
             // try to create a new track
             if source == .camera {
-                let localTrack = LocalVideoTrack.createCameraTrack(options: videoTrackOptions,
-                                                                   interceptor: interceptor)
+                let localTrack = LocalVideoTrack.createCameraTrack()
                 return publishVideoTrack(track: localTrack).then { publication in return publication }
             } else if source == .microphone {
-                let localTrack = LocalAudioTrack.createTrack(name: "", options: audioTrackOptions)
+                let localTrack = LocalAudioTrack.createTrack(name: "")
                 return publishAudioTrack(track: localTrack).then { publication in return publication }
             } else if source == .screenShareVideo {
 

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -236,12 +236,17 @@ public class LocalParticipant: Participant {
 
 extension LocalParticipant {
 
-    public func setCamera(enabled: Bool, interceptor: VideoCaptureInterceptor? = nil) -> Promise<LocalTrackPublication?> {
-        return set(source: .camera, enabled: enabled, interceptor: interceptor)
+    public func setCamera(enabled: Bool,
+                          options: LocalVideoTrackOptions? = nil,
+                          interceptor: VideoCaptureInterceptor? = nil) -> Promise<LocalTrackPublication?> {
+
+        return set(source: .camera, enabled: enabled, videoTrackOptions: options, interceptor: interceptor)
     }
 
-    public func setMicrophone(enabled: Bool) -> Promise<LocalTrackPublication?> {
-        return set(source: .microphone, enabled: enabled)
+    public func setMicrophone(enabled: Bool,
+                              options: LocalAudioTrackOptions? = nil) -> Promise<LocalTrackPublication?> {
+
+        return set(source: .microphone, enabled: enabled, audioTrackOptions: options)
     }
 
     public func setScreenShare(enabled: Bool, source: ScreenShareSource? = nil) -> Promise<LocalTrackPublication?> {
@@ -250,6 +255,8 @@ extension LocalParticipant {
 
     public func set(source: Track.Source,
                     enabled: Bool,
+                    videoTrackOptions: LocalVideoTrackOptions? = nil,
+                    audioTrackOptions: LocalAudioTrackOptions? = nil,
                     screenShareSource: ScreenShareSource? = nil,
                     interceptor: VideoCaptureInterceptor? = nil) -> Promise<LocalTrackPublication?> {
 
@@ -273,10 +280,11 @@ extension LocalParticipant {
         } else if enabled {
             // try to create a new track
             if source == .camera {
-                let localTrack = LocalVideoTrack.createCameraTrack(interceptor: interceptor)
+                let localTrack = LocalVideoTrack.createCameraTrack(options: videoTrackOptions,
+                                                                   interceptor: interceptor)
                 return publishVideoTrack(track: localTrack).then { publication in return publication }
             } else if source == .microphone {
-                let localTrack = LocalAudioTrack.createTrack(name: "")
+                let localTrack = LocalAudioTrack.createTrack(name: "", options: audioTrackOptions)
                 return publishAudioTrack(track: localTrack).then { publication in return publication }
             } else if source == .screenShareVideo {
 

--- a/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
+++ b/Sources/LiveKit/Track/Capturers/CameraCapturer.swift
@@ -26,9 +26,9 @@ public class CameraCapturer: VideoCapturer {
     }
 
     init(delegate: RTCVideoCapturerDelegate,
-         options: LocalVideoTrackOptions = LocalVideoTrackOptions()) {
+         options: LocalVideoTrackOptions? = nil) {
         self.capturer = RTCCameraVideoCapturer(delegate: delegate)
-        self.options = options
+        self.options = options ?? LocalVideoTrackOptions()
         super.init(delegate: delegate)
     }
 
@@ -147,7 +147,7 @@ public class CameraCapturer: VideoCapturer {
 
 extension LocalVideoTrack {
 
-    public static func createCameraTrack(options: LocalVideoTrackOptions = LocalVideoTrackOptions(),
+    public static func createCameraTrack(options: LocalVideoTrackOptions? = nil,
                                          interceptor: VideoCaptureInterceptor? = nil) -> LocalVideoTrack {
         let source: RTCVideoCapturerDelegate
         let output: RTCVideoSource

--- a/Sources/LiveKit/Track/LocalAudioTrack.swift
+++ b/Sources/LiveKit/Track/LocalAudioTrack.swift
@@ -4,7 +4,9 @@ import WebRTC
 public class LocalAudioTrack: AudioTrack {
 
     public static func createTrack(name: String,
-                                   options: LocalAudioTrackOptions = LocalAudioTrackOptions()) -> LocalAudioTrack {
+                                   options: LocalAudioTrackOptions? = nil) -> LocalAudioTrack {
+
+        let options = options ?? LocalAudioTrackOptions()
 
         let constraints: [String: String] = [
             "googEchoCancellation": options.echoCancellation.toString(),


### PR DESCRIPTION
I can add the default options to `ConnectOptions` but that will be only used when calling
`setCameraEnabled` `setMicrophoneEnabled` etc since creating track directly by `LocalAudioTrack.createTrack` has no access to the `Room.connectOptions`

https://linear.app/livekit/issue/LK-318/swift-support-default-capture-settings