### PR TITLE
Session migration

### DIFF
--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -399,7 +399,7 @@ extension Engine: SignalClientDelegate {
 
     func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) -> Bool {
         log()
-        
+
         // Server indicates it's not recoverable
         if !canReconnect {
             cleanUp(reason: .network())
@@ -407,7 +407,7 @@ extension Engine: SignalClientDelegate {
 
         return true
     }
-    
+
     func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) -> Bool {
         let transport = target == .subscriber ? subscriber : publisher
         transport?.addIceCandidate(iceCandidate)

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -549,7 +549,7 @@ extension Engine: TransportDelegate {
     }
 
     func transport(_ transport: Transport, didUpdate state: RTCPeerConnectionState) {
-        log("state: \(state)")
+        log("target: \(transport.target), state: \(state)")
         if transport.primary, state == .failed {
             reconnect()
         }
@@ -563,7 +563,7 @@ extension Engine: TransportDelegate {
     }
 
     func transport(_ transport: Transport, didOpen dataChannel: RTCDataChannel) {
-        log("did add track] did open datachannel")
+        log("Did open dataChannel label: \(dataChannel.label)")
         if subscriberPrimary, transport.target == .subscriber {
             onReceived(dataChannel: dataChannel)
         }

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -45,8 +45,11 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
         self.signalClient = signalClient
         super.init()
 
+        // Room
         add(delegate: room)
+        signalClient.add(delegate: room)
 
+        // Self
         signalClient.add(delegate: self)
         log()
     }

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -41,6 +41,7 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
 
     public init(room: Room,
                 signalClient: SignalClient = SignalClient()) {
+
         self.room = room
         self.signalClient = signalClient
         super.init()

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -483,7 +483,7 @@ extension Engine: SignalClientDelegate {
         log("received track published confirmation from server for: \(localTrack.track.sid)")
     }
 
-    func signalClientDidLeave(_ signaClient: SignalClient) {
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) {
         disconnect()
     }
 

--- a/Sources/LiveKit/Core/Engine.swift
+++ b/Sources/LiveKit/Core/Engine.swift
@@ -269,7 +269,7 @@ internal class Engine: MulticastDelegate<EngineDelegate> {
     }
 }
 
-// MARK: - Wait extension
+// MARK: - Wait extensions
 
 extension Engine {
 
@@ -434,14 +434,6 @@ extension Engine: SignalClientDelegate {
         }
     }
 
-    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) {
-        notify { $0.engine(self, didUpdateSignal: speakers) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) {
-        notify { $0.engine(self, didUpdate: connectionQuality)}
-    }
-
     func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {
         //
     }
@@ -499,26 +491,6 @@ extension Engine: SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didFailConnect error: Error) {
         log("signal connection error: \(error)")
         notify { $0.engine(self, didFailConnection: error) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) {
-        notify { $0.engine(self, didUpdateRemoteMute: trackSid, muted: muted) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) {
-        notify { $0.engine(self, didUpdate: participants) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) {
-        notify { $0.engine(self, didUpdate: trackStates) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {
-        notify { $0.engine(self, didUpdate: trackSid, subscribedQualities: subscribedQualities) }
-    }
-
-    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {
-        notify { $0.engine(self, didUpdate: subscriptionPermission) }
     }
 }
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -210,7 +210,12 @@ public class Room: MulticastDelegate<RoomDelegate> {
     }
 }
 
-// MARK: - RTCEngineDelegate
+// MARK: - SignalClientDelegate
+
+extension Room: SignalClientDelegate {
+}
+
+// MARK: - EngineDelegate
 
 extension Room: EngineDelegate {
 

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -244,7 +244,9 @@ extension Room: SignalClientDelegate {
         log()
 
         if connectionState.isReconnecting {
-            sendSyncState()
+            sendSyncState().catch { error in
+                self.log("Failed to send sync state, error: \(error)", .error)
+            }
         }
 
         return true

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -194,6 +194,13 @@ public class Room: MulticastDelegate<RoomDelegate> {
     }
 }
 
+extension Room {
+    
+    public func sendSimulate(scenario: SimulateScenario) -> Promise<Void> {
+        engine.signalClient.sendSimulate(scenario: scenario)
+    }
+}
+
 // MARK: - Session Migration
 
 extension Room {

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -207,6 +207,7 @@ extension Room {
 extension Room {
 
     internal func sendSyncState() -> Promise<Void> {
+        log()
 
         guard let subscriber = engine.subscriber,
               let localDescription = subscriber.localDescription else {
@@ -239,12 +240,14 @@ extension Room {
 
 extension Room: SignalClientDelegate {
 
-    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {
-        log("isReconnect: \(isReconnect)")
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) -> Bool {
+        log()
 
         if connectionState.isReconnecting {
             sendSyncState()
         }
+
+        return true
     }
 
     func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) -> Bool {

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -210,9 +210,19 @@ public class Room: MulticastDelegate<RoomDelegate> {
     }
 }
 
+// MARK: - Session Migration
+
+extension Room {
+    
+}
+
 // MARK: - SignalClientDelegate
 
 extension Room: SignalClientDelegate {
+
+    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {
+        log()
+    }
 }
 
 // MARK: - EngineDelegate

--- a/Sources/LiveKit/Core/Room.swift
+++ b/Sources/LiveKit/Core/Room.swift
@@ -195,7 +195,8 @@ public class Room: MulticastDelegate<RoomDelegate> {
 }
 
 extension Room {
-    
+
+    @discardableResult
     public func sendSimulate(scenario: SimulateScenario) -> Promise<Void> {
         engine.signalClient.sendSimulate(scenario: scenario)
     }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -170,8 +170,8 @@ internal class SignalClient: MulticastDelegate<SignalClientDelegate> {
         case .mute(let mute):
             notify { $0.signalClient(self, didUpdateRemoteMute: mute.sid, muted: mute.muted) }
 
-        case .leave:
-            notify { $0.signalClientDidLeave(self) }
+        case .leave(let leave):
+            notify { $0.signalClient(self, didReceiveLeave: leave.canReconnect) }
 
         case .streamStateUpdate(let states):
             notify { $0.signalClient(self, didUpdate: states.streamStates) }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -225,7 +225,7 @@ internal extension SignalClient {
 internal extension SignalClient {
 
     func sendOffer(offer: RTCSessionDescription) {
-        log("Sending offer")
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.offer = offer.toPBType()
@@ -235,7 +235,7 @@ internal extension SignalClient {
     }
 
     func sendAnswer(answer: RTCSessionDescription) {
-        log("Sending answer")
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.answer = answer.toPBType()
@@ -245,7 +245,7 @@ internal extension SignalClient {
     }
 
     func sendCandidate(candidate: RTCIceCandidate, target: Livekit_SignalTarget) throws {
-        log("Sending ICE candidate")
+        log("target: \(target)")
 
         let r = try Livekit_SignalRequest.with {
             $0.trickle = try Livekit_TrickleRequest.with {
@@ -258,7 +258,7 @@ internal extension SignalClient {
     }
 
     func sendMuteTrack(trackSid: String, muted: Bool) {
-        log("Sending mute for \(trackSid), muted: \(muted)")
+        log("trackSid: \(trackSid), muted: \(muted)")
 
         let r = Livekit_SignalRequest.with {
             $0.mute = Livekit_MuteTrackRequest.with {
@@ -275,7 +275,8 @@ internal extension SignalClient {
                       type: Livekit_TrackType,
                       source: Livekit_TrackSource = .unknown,
                       _ populator: (inout Livekit_AddTrackRequest) -> Void) {
-        log("Sending add track request")
+        log()
+
         let r = Livekit_SignalRequest.with {
             $0.addTrack = Livekit_AddTrackRequest.with {
                 populator(&$0)
@@ -293,7 +294,7 @@ internal extension SignalClient {
                                  enabled: Bool,
                                  width: Int = 0,
                                  height: Int = 0) {
-        log("Sending update track settings")
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.trackSetting = Livekit_UpdateTrackSettings.with {
@@ -309,6 +310,7 @@ internal extension SignalClient {
 
     func sendUpdateVideoLayers(trackSid: String,
                                layers: [Livekit_VideoLayer]) {
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.updateLayers = Livekit_UpdateVideoLayers.with {
@@ -321,7 +323,7 @@ internal extension SignalClient {
     }
 
     func sendUpdateSubscription(sid: String, subscribed: Bool) {
-        log("Sending update subscription")
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.subscription = Livekit_UpdateSubscription.with {
@@ -335,6 +337,8 @@ internal extension SignalClient {
 
     func sendUpdateSubscriptionPermissions(allParticipants: Bool,
                                            participantTrackPermissions: [ParticipantTrackPermission]) {
+        log()
+
         let r = Livekit_SignalRequest.with {
             $0.subscriptionPermissions = Livekit_UpdateSubscriptionPermissions.with {
                 $0.allParticipants = allParticipants
@@ -345,8 +349,24 @@ internal extension SignalClient {
         sendRequest(r)
     }
 
+    func sendSyncState(answer: Livekit_SessionDescription,
+                       subscription: Livekit_UpdateSubscription,
+                       publishTracks: [Livekit_TrackPublishedResponse]) {
+        log()
+
+        let r = Livekit_SignalRequest.with {
+            $0.syncState = Livekit_SyncState.with {
+                $0.answer = answer
+                $0.subscription = subscription
+                $0.publishTracks = publishTracks
+            }
+        }
+
+        sendRequest(r)
+    }
+
     func sendLeave() {
-        log("Sending leave")
+        log()
 
         let r = Livekit_SignalRequest.with {
             $0.leave = Livekit_LeaveRequest()

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -351,14 +351,14 @@ internal extension SignalClient {
 
     func sendSyncState(answer: Livekit_SessionDescription,
                        subscription: Livekit_UpdateSubscription,
-                       publishTracks: [Livekit_TrackPublishedResponse]) {
+                       publishTracks: [Livekit_TrackPublishedResponse]?) {
         log()
 
         let r = Livekit_SignalRequest.with {
             $0.syncState = Livekit_SyncState.with {
                 $0.answer = answer
                 $0.subscription = subscription
-                $0.publishTracks = publishTracks
+                $0.publishTracks = publishTracks ?? []
             }
         }
 

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -373,4 +373,19 @@ internal extension SignalClient {
 
         return sendRequest(r)
     }
+    
+    func sendSimulate(scenario: SimulateScenario) -> Promise<Void> {
+        log()
+
+        let r = Livekit_SignalRequest.with {
+            $0.simulate = Livekit_SimulateScenario.with {
+                if case .nodeFailure = scenario { $0.nodeFailure = true }
+                if case .migration = scenario { $0.migration = true }
+                if case .serverLeave = scenario { $0.serverLeave = true }
+                if case .speakerUpdate(let secs) = scenario { $0.speakerUpdate = Int32(secs) }
+            }
+        }
+
+        return sendRequest(r)
+    }
 }

--- a/Sources/LiveKit/Core/SignalClient.swift
+++ b/Sources/LiveKit/Core/SignalClient.swift
@@ -53,7 +53,7 @@ internal class SignalClient: MulticastDelegate<SignalClientDelegate> {
                                          })
             }.then(on: .sdk) { (webSocket: WebSocket) -> Void in
                 self.webSocket = webSocket
-                self.connectionState = .connected()
+                self.connectionState = .connected(didReconnect: reconnect)
             }.recover(on: .sdk) { error -> Promise<Void> in
                 // Skip validation if reconnect mode
                 if reconnect { throw error }
@@ -77,7 +77,6 @@ internal class SignalClient: MulticastDelegate<SignalClientDelegate> {
                 }
             }.catch(on: .sdk) { _ in
                 self.cleanUp(reason: .network())
-                // self.connectionState = .disconnected(error: SignalClientError.connect())
             }
     }
 
@@ -372,7 +371,7 @@ internal extension SignalClient {
 
         return sendRequest(r)
     }
-    
+
     func sendSimulate(scenario: SimulateScenario) -> Promise<Void> {
         log()
 

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -3,7 +3,7 @@ import Promises
 import WebRTC
 import SwiftProtobuf
 
-typealias TransportOnOffer = (RTCSessionDescription) -> Void
+typealias TransportOnOffer = (RTCSessionDescription) -> Promise<Void>
 
 internal class Transport: MulticastDelegate<TransportDelegate> {
 

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -22,6 +22,10 @@ internal class Transport: MulticastDelegate<TransportDelegate> {
         DispatchQueue.webRTC.sync { pc.connectionState }
     }
 
+    public var localDescription: RTCSessionDescription? {
+        DispatchQueue.webRTC.sync { pc.localDescription }
+    }
+
     public var remoteDescription: RTCSessionDescription? {
         DispatchQueue.webRTC.sync { pc.remoteDescription }
     }

--- a/Sources/LiveKit/Core/Transport.swift
+++ b/Sources/LiveKit/Core/Transport.swift
@@ -138,6 +138,7 @@ internal class Transport: MulticastDelegate<TransportDelegate> {
         return negotiateSequence()
     }
 
+    // TODO: Make this async
     public func close() {
         // prevent debounced negotiate firing
         debounceWorkItem?.cancel()

--- a/Sources/LiveKit/Errors.swift
+++ b/Sources/LiveKit/Errors.swift
@@ -77,16 +77,17 @@ public enum TrackError: LiveKitError {
 }
 
 public enum SignalClientError: LiveKitError {
+    case state(message: String? = nil)
     case socketError(rawError: Error?)
     case close(message: String? = nil)
     case connect(message: String? = nil)
 
     public var description: String {
         switch self {
+        case .state(let message): return buildDescription("state", message)
         case .socketError(let rawError): return buildDescription("socketError", rawError != nil ? "rawError: \(rawError!.localizedDescription)" : nil)
         case .close(let message): return buildDescription("close", message)
         case .connect(let message): return buildDescription("connect", message)
-
         }
     }
 }

--- a/Sources/LiveKit/Extensions/TimeInterval.swift
+++ b/Sources/LiveKit/Extensions/TimeInterval.swift
@@ -4,5 +4,5 @@ import Foundation
 internal extension TimeInterval {
     static let defaultConnect: Self = 10
     static let defaultPublish: Self = 10
-    static let reconnectDelay: Self = 2
+    static let reconnectDelay: Self = 3
 }

--- a/Sources/LiveKit/Extensions/TimeInterval.swift
+++ b/Sources/LiveKit/Extensions/TimeInterval.swift
@@ -4,4 +4,5 @@ import Foundation
 internal extension TimeInterval {
     static let defaultConnect: Self = 10
     static let defaultPublish: Self = 10
+    static let reconnectDelay: Self = 2
 }

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -278,8 +278,10 @@ public class LocalParticipant: Participant {
      *  participant/track. Any omitted participants will not receive any permissions.
      */
     public func setTrackSubscriptionPermissions(allParticipantsAllowed: Bool,
-                                                trackPermissions: [ParticipantTrackPermission] = []) {
-        room.engine.signalClient.sendUpdateSubscriptionPermissions(allParticipants: allParticipantsAllowed, participantTrackPermissions: trackPermissions)
+                                                trackPermissions: [ParticipantTrackPermission] = []) -> Promise<Void> {
+
+        return room.engine.signalClient.sendUpdateSubscriptionPermissions(allParticipants: allParticipantsAllowed,
+                                                                          participantTrackPermissions: trackPermissions)
     }
 
     internal func onSubscribedQualitiesUpdate(trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {

--- a/Sources/LiveKit/Participant/LocalParticipant.swift
+++ b/Sources/LiveKit/Participant/LocalParticipant.swift
@@ -337,6 +337,23 @@ public class LocalParticipant: Participant {
     }
 }
 
+// MARK: - Session Migration
+
+extension LocalParticipant {
+
+    internal func publishedTracksInfo() -> [Livekit_TrackPublishedResponse] {
+        tracks.values.filter { $0.track != nil }
+            .map { publication in
+                Livekit_TrackPublishedResponse.with {
+                    $0.cid = publication.track!.mediaTrack.trackId
+                    if let info = publication.latestInfo {
+                        $0.track = info
+                    }
+                }
+            }
+    }
+}
+
 // MARK: - Simplified API
 
 extension LocalParticipant {

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -3,22 +3,31 @@ import WebRTC
 
 internal protocol EngineDelegate {
     func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse)
-    func engine(_ engine: Engine, didUpdate participants: [Livekit_ParticipantInfo])
     func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo])
-    func engine(_ engine: Engine, didUpdateSignal speakers: [Livekit_SpeakerInfo])
-    func engine(_ engine: Engine, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo])
-    func engine(_ engine: Engine, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality])
-    func engine(_ engine: Engine, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate)
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream])
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket)
-    func engine(_ engine: Engine, didUpdateRemoteMute trackSid: String, muted: Bool)
     func engine(_ engine: Engine, didUpdate connectionState: ConnectionState)
-    func engine(_ engine: Engine, didUpdate trackStates: [Livekit_StreamStateInfo])
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState)
     func engine(_ engine: Engine, didConnect isReconnect: Bool)
     func engine(_ engine: Engine, didFailConnection error: Error)
     func engineDidDisconnect(_ engine: Engine)
 }
+
+// MARK: - Optional
+
+extension EngineDelegate {
+    func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse) {}
+    func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo]) {}
+    func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream]) {}
+    func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket) {}
+    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
+    func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {}
+    func engine(_ engine: Engine, didConnect isReconnect: Bool) {}
+    func engine(_ engine: Engine, didFailConnection error: Error) {}
+    func engineDidDisconnect(_ engine: Engine) {}
+}
+
+// MARK: - Closures
 
 class EngineDelegateClosures: NSObject, EngineDelegate {
 
@@ -35,20 +44,4 @@ class EngineDelegateClosures: NSObject, EngineDelegate {
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {
         onDataChannelStateUpdated?(engine, dataChannel, state)
     }
-
-    func engine(_ engine: Engine, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {}
-    func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse) {}
-    func engine(_ engine: Engine, didUpdate participants: [Livekit_ParticipantInfo]) {}
-    func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo]) {}
-    func engine(_ engine: Engine, didUpdateSignal speakers: [Livekit_SpeakerInfo]) {}
-    func engine(_ engine: Engine, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) {}
-    func engine(_ engine: Engine, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {}
-    func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream]) {}
-    func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket) {}
-    func engine(_ engine: Engine, didUpdateRemoteMute trackSid: String, muted: Bool) {}
-    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
-    func engine(_ engine: Engine, didUpdate trackStates: [Livekit_StreamStateInfo]) {}
-    func engine(_ engine: Engine, didConnect isReconnect: Bool) {}
-    func engine(_ engine: Engine, didFailConnection error: Error) {}
-    func engineDidDisconnect(_ engine: Engine) {}
 }

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -2,15 +2,12 @@ import Foundation
 import WebRTC
 
 internal protocol EngineDelegate {
+    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState)
     func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse)
     func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo])
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream])
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket)
-    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState)
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState)
-    func engine(_ engine: Engine, didConnect isReconnect: Bool)
-    func engine(_ engine: Engine, didFailConnection error: Error)
-    func engineDidDisconnect(_ engine: Engine)
 }
 
 // MARK: - Optional
@@ -22,26 +19,30 @@ extension EngineDelegate {
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket) {}
     func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {}
-    func engine(_ engine: Engine, didConnect isReconnect: Bool) {}
-    func engine(_ engine: Engine, didFailConnection error: Error) {}
-    func engineDidDisconnect(_ engine: Engine) {}
 }
 
 // MARK: - Closures
 
-class EngineDelegateClosures: NSObject, EngineDelegate {
+class EngineDelegateClosures: NSObject, EngineDelegate, Loggable {
 
-    typealias OnDataChannelStateUpdated = (_ engine: Engine,
+    typealias DidUpdateDataChannelState = (_ engine: Engine,
                                            _ dataChannel: RTCDataChannel,
                                            _ state: RTCDataChannelState) -> Void
 
-    let onDataChannelStateUpdated: OnDataChannelStateUpdated?
+    let didUpdateDataChannelState: DidUpdateDataChannelState?
 
-    init(onDataChannelStateUpdated: OnDataChannelStateUpdated? = nil) {
-        self.onDataChannelStateUpdated = onDataChannelStateUpdated
+    init(didUpdateDataChannelState: DidUpdateDataChannelState? = nil) {
+
+        self.didUpdateDataChannelState = didUpdateDataChannelState
+        super.init()
+        log()
+    }
+    
+    deinit {
+        log()
     }
 
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {
-        onDataChannelStateUpdated?(engine, dataChannel, state)
+        didUpdateDataChannelState?(engine, dataChannel, state)
     }
 }

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -3,7 +3,6 @@ import WebRTC
 
 internal protocol EngineDelegate {
     func engine(_ engine: Engine, didUpdate connectionState: ConnectionState)
-    func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse)
     func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo])
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream])
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket)
@@ -13,11 +12,10 @@ internal protocol EngineDelegate {
 // MARK: - Optional
 
 extension EngineDelegate {
-    func engine(_ engine: Engine, didReceive joinResponse: Livekit_JoinResponse) {}
+    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
     func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo]) {}
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream]) {}
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket) {}
-    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {}
 }
 
@@ -37,7 +35,7 @@ class EngineDelegateClosures: NSObject, EngineDelegate, Loggable {
         super.init()
         log()
     }
-    
+
     deinit {
         log()
     }

--- a/Sources/LiveKit/Protocols/EngineDelegate.swift
+++ b/Sources/LiveKit/Protocols/EngineDelegate.swift
@@ -2,8 +2,8 @@ import Foundation
 import WebRTC
 
 internal protocol EngineDelegate {
-    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState)
-    func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo])
+    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState, oldState: ConnectionState)
+    func engine(_ engine: Engine, didUpdate speakers: [Livekit_SpeakerInfo])
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream])
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket)
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState)
@@ -12,8 +12,8 @@ internal protocol EngineDelegate {
 // MARK: - Optional
 
 extension EngineDelegate {
-    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState) {}
-    func engine(_ engine: Engine, didUpdateEngine speakers: [Livekit_SpeakerInfo]) {}
+    func engine(_ engine: Engine, didUpdate connectionState: ConnectionState, oldState: ConnectionState) {}
+    func engine(_ engine: Engine, didUpdate speakers: [Livekit_SpeakerInfo]) {}
     func engine(_ engine: Engine, didAdd track: RTCMediaStreamTrack, streams: [RTCMediaStream]) {}
     func engine(_ engine: Engine, didReceive userPacket: Livekit_UserPacket) {}
     func engine(_ engine: Engine, didUpdate dataChannel: RTCDataChannel, state: RTCDataChannelState) {}

--- a/Sources/LiveKit/Protocols/RoomDelegate.swift
+++ b/Sources/LiveKit/Protocols/RoomDelegate.swift
@@ -11,8 +11,7 @@ public protocol RoomDelegate {
     /// Client disconnected from the room unexpectedly.
     func room(_ room: Room, didDisconnect error: Error?)
 
-    /// When a network change has been detected and LiveKit attempts to reconnect to the room.
-    /// When reconnect attempts succeed, the room state will be kept, including tracks that are subscribed/published.
+    /// When the ``ConnectionState`` has updated.
     func room(_ room: Room, didUpdate connectionState: ConnectionState)
 
     /// When a ``RemoteParticipant`` joins after the ``LocalParticipant``.

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -3,40 +3,40 @@ import WebRTC
 
 internal protocol SignalClientDelegate {
 
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState)
-    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse)
-    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription)
-    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription)
-    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget)
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) -> Bool
+    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) -> Bool
+    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) -> Bool
+    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) -> Bool
+    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) -> Bool
     func signalClient(_ signalClient: SignalClient, didPublish localTrack: Livekit_TrackPublishedResponse)
-    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool)
-    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo])
-    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality])
-    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate)
-    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool)
+    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) -> Bool
+    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) -> Bool
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) -> Bool
 }
 
 // MARK: - Optional
 
 extension SignalClientDelegate {
 
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) {}
-    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) {}
-    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) {}
-    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) {}
-    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) -> Bool { false }
     func signalClient(_ signalClient: SignalClient, didPublish localTrack: Livekit_TrackPublishedResponse) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {}
-    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) -> Bool { false }
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) -> Bool { false }
 }
 
 // MARK: - Closures
@@ -66,12 +66,14 @@ class SignalClientDelegateClosures: NSObject, SignalClientDelegate, Loggable {
         log()
     }
 
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) {
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) -> Bool {
         didUpdateConnectionState?(signalClient, connectionState)
+        return true
     }
 
-    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) {
+    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) -> Bool {
         didReceiveJoinResponse?(signalClient, joinResponse)
+        return true
     }
 
     func signalClient(_ signalClient: SignalClient, didPublish localTrack: Livekit_TrackPublishedResponse) {

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -14,13 +14,38 @@ internal protocol SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo])
     func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality])
     func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate)
-    func signalClientDidLeave(_ signaClient: SignalClient)
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool)
     func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool)
     // Initial connect has failed
     func signalClient(_ signalClient: SignalClient, didFailConnect error: Error)
     // An open connection has closed (disconnected)
     func signalClient(_ signalClient: SignalClient, didClose code: URLSessionWebSocketTask.CloseCode)
 }
+
+// MARK: - Optional
+
+extension SignalClientDelegate {
+    func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) {}
+    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) {}
+    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) {}
+    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) {}
+    func signalClient(_ signalClient: SignalClient, didPublish localTrack: Livekit_TrackPublishedResponse) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) {}
+    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {}
+    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {}
+    func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) {}
+    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {}
+    // Initial connect has failed
+    func signalClient(_ signalClient: SignalClient, didFailConnect error: Error) {}
+    // An open connection has closed (disconnected)
+    func signalClient(_ signalClient: SignalClient, didClose code: URLSessionWebSocketTask.CloseCode) {}
+}
+
+// MARK: - Closures
 
 class SignalClientDelegateClosures: NSObject, SignalClientDelegate, Loggable {
 
@@ -73,16 +98,4 @@ class SignalClientDelegateClosures: NSObject, SignalClientDelegate, Loggable {
     func signalClient(_ signalClient: SignalClient, didPublish localTrack: Livekit_TrackPublishedResponse) {
         didPublishLocalTrack?(signalClient, localTrack)
     }
-
-    func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) {}
-    func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) {}
-    func signalClient(_ signalClient: SignalClient, didReceive iceCandidate: RTCIceCandidate, target: Livekit_SignalTarget) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate participants: [Livekit_ParticipantInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate speakers: [Livekit_SpeakerInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate connectionQuality: [Livekit_ConnectionQualityInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdateRemoteMute trackSid: String, muted: Bool) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate trackStates: [Livekit_StreamStateInfo]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {}
-    func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {}
-    func signalClientDidLeave(_ signaClient: SignalClient) {}
 }

--- a/Sources/LiveKit/Protocols/SignalClientDelegate.swift
+++ b/Sources/LiveKit/Protocols/SignalClientDelegate.swift
@@ -2,6 +2,8 @@ import Foundation
 import WebRTC
 
 internal protocol SignalClientDelegate {
+
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState)
     func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse)
     func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription)
     func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription)
@@ -15,16 +17,13 @@ internal protocol SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality])
     func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate)
     func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool)
-    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool)
-    // Initial connect has failed
-    func signalClient(_ signalClient: SignalClient, didFailConnect error: Error)
-    // An open connection has closed (disconnected)
-    func signalClient(_ signalClient: SignalClient, didClose code: URLSessionWebSocketTask.CloseCode)
 }
 
 // MARK: - Optional
 
 extension SignalClientDelegate {
+
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) {}
     func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) {}
     func signalClient(_ signalClient: SignalClient, didReceiveAnswer answer: RTCSessionDescription) {}
     func signalClient(_ signalClient: SignalClient, didReceiveOffer offer: RTCSessionDescription) {}
@@ -38,37 +37,25 @@ extension SignalClientDelegate {
     func signalClient(_ signalClient: SignalClient, didUpdate trackSid: String, subscribedQualities: [Livekit_SubscribedQuality]) {}
     func signalClient(_ signalClient: SignalClient, didUpdate subscriptionPermission: Livekit_SubscriptionPermissionUpdate) {}
     func signalClient(_ signalClient: SignalClient, didReceiveLeave canReconnect: Bool) {}
-    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {}
-    // Initial connect has failed
-    func signalClient(_ signalClient: SignalClient, didFailConnect error: Error) {}
-    // An open connection has closed (disconnected)
-    func signalClient(_ signalClient: SignalClient, didClose code: URLSessionWebSocketTask.CloseCode) {}
 }
 
 // MARK: - Closures
 
 class SignalClientDelegateClosures: NSObject, SignalClientDelegate, Loggable {
 
-    typealias DidConnect = (SignalClient, Bool) -> Void
-    typealias DidFailConnection = (SignalClient, Error) -> Void
-    typealias DidClose = (SignalClient, URLSessionWebSocketTask.CloseCode) -> Void
+    typealias DidUpdateConnectionState = (SignalClient, ConnectionState) -> Void
     typealias DidReceiveJoinResponse = (SignalClient, Livekit_JoinResponse) -> Void
     typealias DidPublishLocalTrack = (SignalClient, Livekit_TrackPublishedResponse) -> Void
 
-    let didConnect: DidConnect?
-    let didFailConnection: DidFailConnection?
-    let didClose: DidClose?
+    let didUpdateConnectionState: DidUpdateConnectionState?
     let didReceiveJoinResponse: DidReceiveJoinResponse?
     let didPublishLocalTrack: DidPublishLocalTrack?
 
-    init(didConnect: DidConnect? = nil,
-         didFailConnection: DidFailConnection? = nil,
-         didClose: DidClose? = nil,
+    init(didUpdateConnectionState: DidUpdateConnectionState? = nil,
          didReceiveJoinResponse: DidReceiveJoinResponse? = nil,
          didPublishLocalTrack: DidPublishLocalTrack? = nil) {
-        self.didConnect = didConnect
-        self.didFailConnection = didFailConnection
-        self.didClose = didClose
+
+        self.didUpdateConnectionState = didUpdateConnectionState
         self.didReceiveJoinResponse = didReceiveJoinResponse
         self.didPublishLocalTrack = didPublishLocalTrack
         super.init()
@@ -79,16 +66,8 @@ class SignalClientDelegateClosures: NSObject, SignalClientDelegate, Loggable {
         log()
     }
 
-    func signalClient(_ signalClient: SignalClient, didConnect isReconnect: Bool) {
-        didConnect?(signalClient, isReconnect)
-    }
-
-    func signalClient(_ signalClient: SignalClient, didFailConnect error: Error) {
-        didFailConnection?(signalClient, error)
-    }
-
-    func signalClient(_ signalClient: SignalClient, didClose code: URLSessionWebSocketTask.CloseCode) {
-        didClose?(signalClient, code)
+    func signalClient(_ signalClient: SignalClient, didUpdate connectionState: ConnectionState) {
+        didUpdateConnectionState?(signalClient, connectionState)
     }
 
     func signalClient(_ signalClient: SignalClient, didReceive joinResponse: Livekit_JoinResponse) {

--- a/Sources/LiveKit/Publications/LocalTrackPublication.swift
+++ b/Sources/LiveKit/Publications/LocalTrackPublication.swift
@@ -91,7 +91,9 @@ extension LocalTrackPublication {
         log("Sending update video layers request: \(layers)")
 
         participant.room.engine.signalClient.sendUpdateVideoLayers(trackSid: sid,
-                                                                   layers: layers)
+                                                                   layers: layers).catch { error in
+                                                                    self.log("Failed to send update video layers", .error)
+                                                                   }
     }
 }
 

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -117,12 +117,12 @@ public class RemoteTrackPublication: TrackPublication {
     /// subscribe or unsubscribe from this track
     public func setSubscribed(_ subscribed: Bool) {
         unsubscribed = !subscribed
-        guard let client = participant?.room.engine.signalClient else {
-            return
-        }
+        guard let client = participant?.room.engine.signalClient else { return }
 
         client.sendUpdateSubscription(sid: sid,
-                                      subscribed: !unsubscribed)
+                                      subscribed: !unsubscribed).catch { error in
+                                        self.log("Failed to set subscribed, error: \(error)", .error)
+                                      }
     }
 
     /// disable server from sending down data for this track
@@ -131,8 +131,11 @@ public class RemoteTrackPublication: TrackPublication {
     public func setEnabled(_ enabled: Bool) {
         self.enabled = enabled
         guard let client = participant?.room.engine.signalClient else { return }
+
         client.sendUpdateTrackSettings(sid: sid,
-                                       enabled: enabled)
+                                       enabled: enabled).catch { error in
+                                        self.log("Failed to set enabled, error: \(error)", .error)
+                                       }
     }
 
     #if LK_FEATURE_ADAPTIVESTREAM
@@ -227,7 +230,9 @@ extension RemoteTrackPublication {
         // only send if different from previously sent settings
         if videoSettings != lastSentVideoTrackSettings {
             lastSentVideoTrackSettings = videoSettings
-            send(videoSettings)
+            send(videoSettings).catch { error in
+                self.log("Failed to send track settings, error: \(error)", .error)
+            }
         }
     }
 }

--- a/Sources/LiveKit/Publications/RemoteTrackPublication.swift
+++ b/Sources/LiveKit/Publications/RemoteTrackPublication.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreGraphics
+import Promises
 
 public class RemoteTrackPublication: TrackPublication {
     // have we explicitly unsubscribed
@@ -200,13 +201,17 @@ extension RemoteTrackPublication {
 
     private func recomputeVideoViewVisibilities() {
 
-        func send(_ settings: VideoTrackSettings) {
-            guard let client = participant?.room.engine.signalClient else { return }
+        func send(_ settings: VideoTrackSettings) -> Promise<Void> {
+
+            guard let client = participant?.room.engine.signalClient else {
+                return Promise(EngineError.state(message: "Participant is nil"))
+            }
+
             log("sendUpdateTrackSettings enabled: \(settings.enabled), viewSize: \(settings.size)")
-            client.sendUpdateTrackSettings(sid: sid,
-                                           enabled: settings.enabled,
-                                           width: Int(ceil(settings.size.width)),
-                                           height: Int(ceil(settings.size.height)))
+            return client.sendUpdateTrackSettings(sid: sid,
+                                                  enabled: settings.enabled,
+                                                  width: Int(ceil(settings.size.width)),
+                                                  height: Int(ceil(settings.size.height)))
         }
 
         // set internal enabled var

--- a/Sources/LiveKit/Publications/TrackPublication.swift
+++ b/Sources/LiveKit/Publications/TrackPublication.swift
@@ -42,6 +42,8 @@ public class TrackPublication: TrackDelegate, Loggable {
 
     public var subscribed: Bool { return track != nil }
 
+    internal private(set) var latestInfo: Livekit_TrackInfo?
+
     internal init(info: Livekit_TrackInfo,
                   track: Track? = nil,
                   participant: Participant? = nil) {
@@ -68,6 +70,7 @@ public class TrackPublication: TrackDelegate, Loggable {
             dimensions = Dimensions(width: Int32(info.width),
                                     height: Int32(info.height))
         }
+        self.latestInfo = info
     }
 
     // MARK: - TrackDelegate

--- a/Sources/LiveKit/Support/MulticastDelegate.swift
+++ b/Sources/LiveKit/Support/MulticastDelegate.swift
@@ -48,6 +48,28 @@ public class MulticastDelegate<T>: NSObject, Loggable {
             }
         }
     }
+
+    /// At least one delegate must return `true`, otherwise a `warning` will be logged
+    internal func notify(_ fnc: @escaping (T) -> Bool,
+                         function: String = #function,
+                         line: UInt = #line) {
+
+        queue.async {
+            var isHandled: Bool = false
+            for delegate in self.set.objectEnumerator() {
+                guard let delegate = delegate as? T else {
+                    self.log("MulticastDelegate: skipping notify for \(delegate), not a type of \(T.self)", .info)
+                    continue
+                }
+
+                if fnc(delegate) { isHandled = true }
+            }
+
+            if !isHandled {
+                self.log("Notify was not handled, called from \(function) line \(line)", .warning)
+            }
+        }
+    }
 }
 
 public protocol MulticastDelegateCapable {

--- a/Sources/LiveKit/SwiftUISupport/ObservableRoom.swift
+++ b/Sources/LiveKit/SwiftUISupport/ObservableRoom.swift
@@ -73,7 +73,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
 
                 self.cameraTrackState = .published(publication)
             }
-        }.catch { error in
+        }.catch(on: .sdk) { error in
             DispatchQueue.main.async {
                 self.cameraTrackState = .notPublished(error: error)
             }
@@ -105,7 +105,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
 
                 self.screenShareTrackState = .published(publication)
             }
-        }.catch { error in
+        }.catch(on: .sdk) { error in
             DispatchQueue.main.async {
                 self.screenShareTrackState = .notPublished(error: error)
             }
@@ -137,7 +137,7 @@ open class ObservableRoom: ObservableObject, RoomDelegate, Loggable {
 
                 self.microphoneTrackState = .published(publication)
             }
-        }.catch { error in
+        }.catch(on: .sdk) { error in
             DispatchQueue.main.async {
                 self.microphoneTrackState = .notPublished(error: error)
             }

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public enum ConnectionState {
-    case disconnected(error: Error? = nil)
+    case disconnected(reason: DisconnectReason? = nil)
     case connecting(isReconnecting: Bool)
-    case connected
+    case connected(didReconnect: Bool = false)
 }
 
 extension ConnectionState: Equatable {
@@ -27,5 +27,22 @@ extension ConnectionState: Equatable {
     public var isReconnecting: Bool {
         if case .connecting(isReconnecting: true) = self { return true }
         return false
+    }
+}
+
+public enum DisconnectReason {
+    case user // User initiated
+    case network(error: Error? = nil)
+    case sdk // 
+}
+
+extension DisconnectReason {
+
+    var error: Error? {
+        if case .network(let error) = self {
+            return error
+        }
+
+        return nil
     }
 }

--- a/Sources/LiveKit/Types/ConnectionState.swift
+++ b/Sources/LiveKit/Types/ConnectionState.swift
@@ -33,7 +33,7 @@ extension ConnectionState: Equatable {
 public enum DisconnectReason {
     case user // User initiated
     case network(error: Error? = nil)
-    case sdk // 
+    case sdk //
 }
 
 extension DisconnectReason {

--- a/Sources/LiveKit/Types/Options/ConnectOptions.swift
+++ b/Sources/LiveKit/Types/Options/ConnectOptions.swift
@@ -10,7 +10,7 @@ public class ConnectOptions {
     public init(autoSubscribe: Bool = true,
                 rtcConfiguration: RTCConfiguration = .liveKitDefault(),
                 publish: String? = nil,
-                protocolVersion: ProtocolVersion = .v5) {
+                protocolVersion: ProtocolVersion = .v6) {
 
         self.autoSubscribe = autoSubscribe
         self.rtcConfiguration = rtcConfiguration

--- a/Sources/LiveKit/Types/Other.swift
+++ b/Sources/LiveKit/Types/Other.swift
@@ -3,9 +3,9 @@ import WebRTC
 
 public typealias Sid = String
 
-public enum Reliability: Int {
-    case reliable = 0
-    case lossy = 1
+public enum Reliability {
+    case reliable
+    case lossy
 }
 
 extension Reliability {

--- a/Sources/LiveKit/Types/Other.swift
+++ b/Sources/LiveKit/Types/Other.swift
@@ -15,3 +15,10 @@ extension Reliability {
         return .reliable
     }
 }
+
+public enum SimulateScenario {
+    case nodeFailure
+    case migration
+    case serverLeave
+    case speakerUpdate(seconds: Int)
+}

--- a/Sources/LiveKit/Types/ProtocolVersion.swift
+++ b/Sources/LiveKit/Types/ProtocolVersion.swift
@@ -5,6 +5,7 @@ public enum ProtocolVersion {
     case v3
     case v4
     case v5
+    case v6
 }
 
 extension ProtocolVersion: CustomStringConvertible {
@@ -15,6 +16,7 @@ extension ProtocolVersion: CustomStringConvertible {
         case .v3: return "3"
         case .v4: return "4"
         case .v5: return "5"
+        case .v6: return "6"
         }
     }
 }

--- a/Sources/LiveKit/Types/SessionDescription.swift
+++ b/Sources/LiveKit/Types/SessionDescription.swift
@@ -10,9 +10,7 @@ extension RTCSessionDescription {
         case .answer: sd.type = "answer"
         case .offer: sd.type = "offer"
         case .prAnswer: sd.type = "pranswer"
-        default:
-            // This should never happen
-            fatalError("Unknown state \(type)")
+        default: fatalError("Unknown state \(type)") // This should never happen
         }
 
         return sd
@@ -27,9 +25,7 @@ extension Livekit_SessionDescription {
         case "answer": sdpType = .answer
         case "offer": sdpType = .offer
         case "pranswer": sdpType = .prAnswer
-        default:
-            // This should never happen
-            fatalError("Unknown state \(type)")
+        default: fatalError("Unknown state \(type)") // This should never happen
         }
 
         return Engine.createSessionDescription(type: sdpType, sdp: sdp)

--- a/Sources/LiveKit/Views/VideoView.swift
+++ b/Sources/LiveKit/Views/VideoView.swift
@@ -38,9 +38,9 @@ public class VideoView: NativeView, Loggable {
             markNeedsLayout()
             // notify dimensions update
             guard let dimensions = dimensions else { return }
-            track?.notify { [weak track] in
+            track?.notify { [weak track] (delegate) -> Void in
                 guard let track = track else { return }
-                $0.track(track, videoView: self, didUpdate: dimensions)
+                delegate.track(track, videoView: self, didUpdate: dimensions)
             }
         }
     }
@@ -76,9 +76,9 @@ public class VideoView: NativeView, Loggable {
                 oldValue.notify { $0.track(oldValue, didDetach: self) }
             }
             track?.addRenderer(rendererView)
-            track?.notify { [weak track] in
+            track?.notify { [weak track] (delegate) -> Void in
                 guard let track = track else { return }
-                $0.track(track, didAttach: self)
+                delegate.track(track, didAttach: self)
             }
         }
     }


### PR DESCRIPTION
### Please don't mind unrelated changes:
- Internal delegates have been organized (warning for unhandled delegates)
- WebSocket fixes
- Room also listens to SignalClient directly so Engine doesn't need to relay a few messages.
- Room, Engine, SignalClient internal `cleanUp` to reset state.